### PR TITLE
FIX - Gracefully handle unevaluable ruleset conditions (null/missing payload fields)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.github.iamrenny.ruleflow</groupId>
     <artifactId>ruleflow</artifactId>
     <name>ruleflow</name>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/rules-cli/pom.xml
+++ b/rules-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.iamrenny.ruleflow</groupId>
         <artifactId>ruleflow</artifactId>
-        <version>0.7.0</version>
+        <version>0.7.1</version>
     </parent>
 
     <name>rules-cli</name>

--- a/rules-interpreter/pom.xml
+++ b/rules-interpreter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.iamrenny.ruleflow</groupId>
         <artifactId>ruleflow</artifactId>
-        <version>0.7.0</version>
+        <version>0.7.1</version>
     </parent>
 
     <name>rules-interpreter</name>

--- a/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/visitors/RulesetVisitor.java
+++ b/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/visitors/RulesetVisitor.java
@@ -46,9 +46,32 @@ public class RulesetVisitor extends RuleFlowLanguageBaseVisitor<WorkflowResult> 
 
         for (RuleFlowLanguageParser.RulesetsContext ruleSet : ctx.rulesets()) {
             if (ruleSet.ruleset_condition() != null) {
-                Object result = visitor.visit(ruleSet.ruleset_condition().expr());
-                if (!(result instanceof Boolean) || !((Boolean) result)) {
-                    continue;
+                try {
+                    Object result = visitor.visit(ruleSet.ruleset_condition().expr());
+                    if (!(result instanceof Boolean) || !((Boolean) result)) {
+                        continue;
+                    }
+                } catch (RuntimeException ex) {
+                    if (ex.getCause() != null && ex.getCause() instanceof PropertyNotFoundException) {
+                        logger.debug("Property not found in ruleset condition: {} {}", ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
+                        warnings.add(ex.getCause().getMessage());
+                        continue; // Skip this ruleset and continue to the next one
+                    } else if (ex.getCause() != null && ex.getCause() instanceof UnexpectedSymbolException) {
+                        logger.warn("Unexpected symbol in ruleset condition: {} {}", ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
+                        warnings.add(ex.getCause().getMessage());
+                        continue; // Skip this ruleset and continue to the next one
+                    } else if (ex.getCause() != null && ex.getCause() instanceof ActionParameterResolutionException) {
+                        logger.warn("Action parameter resolution failed in ruleset condition: {} {}", ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
+                        warnings.add(ex.getCause().getMessage());
+                        continue; // Skip this ruleset and continue to the next one
+                    } else {
+                        logger.error("Error while evaluating ruleset condition {} {}",
+                            ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
+                        warnings.add(ex.getMessage() != null ? ex.getMessage()
+                            : "Unexpected Exception at " + ruleSet.getText());
+                        error = true;
+                        continue; // Skip this ruleset and continue to the next one
+                    }
                 }
             }
             for (RuleFlowLanguageParser.RulesContext rule : ruleSet.rules()) {

--- a/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/visitors/RulesetVisitor.java
+++ b/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/visitors/RulesetVisitor.java
@@ -55,22 +55,22 @@ public class RulesetVisitor extends RuleFlowLanguageBaseVisitor<WorkflowResult> 
                     if (ex.getCause() != null && ex.getCause() instanceof PropertyNotFoundException) {
                         logger.debug("Property not found in ruleset condition: {} {}", ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
                         warnings.add(ex.getCause().getMessage());
-                        continue; // Skip this ruleset and continue to the next one
+                        continue;
                     } else if (ex.getCause() != null && ex.getCause() instanceof UnexpectedSymbolException) {
                         logger.warn("Unexpected symbol in ruleset condition: {} {}", ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
                         warnings.add(ex.getCause().getMessage());
-                        continue; // Skip this ruleset and continue to the next one
+                        continue;
                     } else if (ex.getCause() != null && ex.getCause() instanceof ActionParameterResolutionException) {
                         logger.warn("Action parameter resolution failed in ruleset condition: {} {}", ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
                         warnings.add(ex.getCause().getMessage());
-                        continue; // Skip this ruleset and continue to the next one
+                        continue;
                     } else {
                         logger.error("Error while evaluating ruleset condition {} {}",
                             ctx.workflow_name().getText(), ruleSet.name().getText(), ex);
                         warnings.add(ex.getMessage() != null ? ex.getMessage()
                             : "Unexpected Exception at " + ruleSet.getText());
                         error = true;
-                        continue; // Skip this ruleset and continue to the next one
+                        continue;
                     }
                 }
             }

--- a/rules-interpreter/src/test/java/RulesetConditionTest.java
+++ b/rules-interpreter/src/test/java/RulesetConditionTest.java
@@ -43,4 +43,27 @@ public class RulesetConditionTest {
         WorkflowResult result = new Workflow(workflow).evaluate(Map.of());
         assertEquals("yes", result.getResult());
     }
+
+    @Test
+    void rulesetConditionWithMissingData_shouldSkipFirstRulesetAndEvaluateSecond() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'first' user.age > 18 then
+                    'rule1' (1 = 1 return first_ruleset)
+                ruleset 'second' user.name = 'John' then
+                    'rule2' (1 = 1 return second_ruleset)
+                default return no
+            end
+        """;
+
+        Map<String, Object> payload = Map.of("user", Map.of("name", "John"));
+        
+        WorkflowResult result = new Workflow(workflow).evaluate(payload);
+        assertEquals("second_ruleset", result.getResult());
+        assertEquals("second", result.getRuleSet());
+
+        assertTrue(result.getWarnings().stream()
+            .anyMatch(warning -> warning.contains("age field cannot be found")), 
+            "Should contain warning about missing age field");
+    }
 } 


### PR DESCRIPTION
## Problem
When evaluating ruleset conditions, the system would throw a PropertyNotFoundException and crash the entire workflow if the condition referenced a property that didn't exist in the payload. This prevented the workflow from gracefully continuing to evaluate subsequent rulesets.


Expected behavior: Skip ruleset if it cannot evaluate the condition, continue with the following ruleset
Actual behavior: PropertyNotFoundException: age field cannot be found

## Solution
Implemented consistent error handling for ruleset conditions by applying the same exception handling pattern used for rules inside rulesets:

- Wrapped ruleset condition evaluation in try-catch blocks
- Added graceful degradation for PropertyNotFoundException, UnexpectedSymbolException, and ActionParameterResolutionException
- Implemented proper logging at appropriate levels (debug for missing properties, warning for other issues)
- Added warning collection to inform users about skipped conditions
- Maintained workflow continuity by skipping problematic rulesets and continuing with subsequent ones

## Changes Made

### RulesetVisitor.java
- Added try-catch block around visitor.visit(ruleSet.ruleset_condition().expr())
- Implemented exception handling for:
  - PropertyNotFoundException → Skip ruleset, log debug, add warning
  - UnexpectedSymbolException → Skip ruleset, log warning, add warning  
  - ActionParameterResolutionException → Skip ruleset, log warning, add warning
  - Other exceptions → Skip ruleset, log error, set error flag, add warning

### RulesetConditionTest.java
- Added comprehensive test case rulesetConditionWithMissingData_shouldSkipFirstRulesetAndEvaluateSecond
- Tests scenario where first ruleset condition references missing data
- Verifies second ruleset is properly evaluated
- Asserts warning message is captured for missing property

## Testing
- All existing tests pass - No regression introduced
- New test passes - Confirms bug fix works correctly
- Error handling verified - Missing properties are gracefully handled
- Warning collection verified - Users are informed about skipped conditions

## Impact
- Bug Fix: Resolves workflow crashes due to missing properties in ruleset conditions
- User Experience: Workflows now continue processing instead of failing completely
- Consistency: Ruleset condition error handling now matches rule error handling
- Observability: Users receive warnings about skipped conditions for debugging


