### PR TITLE
Fix: Add missing actionCalls methods to MatchedRuleListItem class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.github.iamrenny.ruleflow</groupId>
     <artifactId>ruleflow</artifactId>
     <name>ruleflow</name>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/rules-cli/pom.xml
+++ b/rules-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.iamrenny.ruleflow</groupId>
         <artifactId>ruleflow</artifactId>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
     </parent>
 
     <name>rules-cli</name>

--- a/rules-interpreter/pom.xml
+++ b/rules-interpreter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.iamrenny.ruleflow</groupId>
         <artifactId>ruleflow</artifactId>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
     </parent>
 
     <name>rules-interpreter</name>

--- a/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/vo/WorkflowResult.java
+++ b/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/vo/WorkflowResult.java
@@ -356,6 +356,35 @@ public class WorkflowResult {
             Map<String, Map<String, String>> actionsWithParams) {
             this.actionsWithParams = actionsWithParams;
             this.actionCalls = WorkflowResult.convertActionsWithParamsToActionCalls(actionsWithParams);
+            this.actions = actionsWithParams.keySet();
+        }
+
+        @Deprecated
+        public void setActionsWithParams(
+            Map<String, Map<String, String>> actionsWithParams, boolean updateActionCalls) {
+            this.actionsWithParams = actionsWithParams;
+            if (updateActionCalls) {
+                this.actionCalls = WorkflowResult.convertActionsWithParamsToActionCalls(actionsWithParams);
+            }
+            this.actions = actionsWithParams.keySet();
+        }
+
+        public List<Action> getActionCalls() {
+            return actionCalls;
+        }
+
+        public void setActionCalls(List<Action> actionCalls) {
+            this.actionCalls = actionCalls != null ? new ArrayList<>(actionCalls) : new ArrayList<>();
+            this.actionsWithParams = convertActionCallsToActionsWithParams(this.actionCalls);
+            this.actions = this.actionCalls.stream().map(Action::getName).collect(Collectors.toSet());
+        }
+
+        public void setActionCalls(List<Action> actionCalls, boolean updateActionsWithParams) {
+            this.actionCalls = actionCalls != null ? new ArrayList<>(actionCalls) : new ArrayList<>();
+            if (updateActionsWithParams) {
+                this.actionsWithParams = convertActionCallsToActionsWithParams(this.actionCalls);
+            }
+            this.actions = this.actionCalls.stream().map(Action::getName).collect(Collectors.toSet());
         }
 
     }

--- a/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/vo/WorkflowResult.java
+++ b/rules-interpreter/src/main/java/io/github/iamrenny/ruleflow/vo/WorkflowResult.java
@@ -359,15 +359,6 @@ public class WorkflowResult {
             this.actions = actionsWithParams.keySet();
         }
 
-        @Deprecated
-        public void setActionsWithParams(
-            Map<String, Map<String, String>> actionsWithParams, boolean updateActionCalls) {
-            this.actionsWithParams = actionsWithParams;
-            if (updateActionCalls) {
-                this.actionCalls = WorkflowResult.convertActionsWithParamsToActionCalls(actionsWithParams);
-            }
-            this.actions = actionsWithParams.keySet();
-        }
 
         public List<Action> getActionCalls() {
             return actionCalls;

--- a/rules-interpreter/src/test/java/ActionCallsTest.java
+++ b/rules-interpreter/src/test/java/ActionCallsTest.java
@@ -1,97 +1,34 @@
 import io.github.iamrenny.ruleflow.vo.WorkflowResult;
-import io.github.iamrenny.ruleflow.vo.Action;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
-import java.util.List;
 
 class ActionCallsTest {
 
     @Test
-    public void actionCalls_should_store_multiple_actions_with_same_name_separately() {
+    public void given_multimatch_workflow_with_three_matching_rules_must_have_correct_actioncalls() {
         String workflow = """
-            workflow 'test'
-                ruleset 'dummy'
-                    'rule_a' user_id = 15 return block with apply_restriction({'test': 'me'}) AND apply_restriction({'responsible': 'homer'})
+            workflow 'multimatch_test'
+                evaluation_mode multi_match
+                ruleset 'security'
+                    'rule_1' user_id = 15 return block with action('manual_review', {'rule': 'rule_1'})
+                    'rule_2' user_id = 15 return block with action('logout_user', {'rule': 'rule_2'})
+                    'rule_3' user_id = 15 return block with action('notify_admin', {'rule': 'rule_3'})
                 default allow
             end
         """;
         Map<String, Object> request = Map.of("user_id", 15);
         WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
         
-        List<Action> actionCalls = result.getActionCalls();
-        Assertions.assertEquals(2, actionCalls.size());
+        // Verify main result has actionCalls from first matched rule only
+        Assertions.assertEquals(1, result.getActionCalls().size());
+        Assertions.assertEquals("manual_review", result.getActionCalls().get(0).getName());
         
-        // Verify both actions have the same name but different parameters
-        Assertions.assertEquals("apply_restriction", actionCalls.get(0).getName());
-        Assertions.assertEquals("apply_restriction", actionCalls.get(1).getName());
-        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(0).getParams());
-        Assertions.assertEquals(Map.of("responsible", "homer"), actionCalls.get(1).getParams());
+        // Verify matchedRules has actionCalls for all 3 rules
+        Assertions.assertEquals(3, result.getMatchedRules().size());
+        Assertions.assertEquals("manual_review", result.getMatchedRules().get(0).getActionCalls().get(0).getName());
+        Assertions.assertEquals("logout_user", result.getMatchedRules().get(1).getActionCalls().get(0).getName());
+        Assertions.assertEquals("notify_admin", result.getMatchedRules().get(2).getActionCalls().get(0).getName());
     }
-
-    @Test
-    public void actionCalls_should_work_with_different_action_names() {
-        String workflow = """
-            workflow 'test'
-                ruleset 'dummy'
-                    'rule_a' user_id = 15 return block with action('manual_review', {'test': 'me'}) and action('logout_user', {'reason': 'suspicious'})
-                default allow
-            end
-        """;
-        Map<String, Object> request = Map.of("user_id", 15);
-        WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
-        
-        List<Action> actionCalls = result.getActionCalls();
-        Assertions.assertEquals(2, actionCalls.size());
-        Assertions.assertEquals("manual_review", actionCalls.get(0).getName());
-        Assertions.assertEquals("logout_user", actionCalls.get(1).getName());
-    }
-
-
-
-    @Test
-    public void actionCalls_should_store_multiple_equal_actions_separately() {
-        String workflow = """
-            workflow 'test'
-                ruleset 'dummy'
-                    'rule_a' user_id = 15 return block with apply_restriction({'test': 'me'}) AND apply_restriction({'test': 'me'})
-                default allow
-            end
-        """;
-        Map<String, Object> request = Map.of("user_id", 15);
-        WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
-
-        List<Action> actionCalls = result.getActionCalls();
-        Assertions.assertEquals(2, actionCalls.size());
-
-        // Verify both actions have the same name but different parameters
-        Assertions.assertEquals("apply_restriction", actionCalls.get(0).getName());
-        Assertions.assertEquals("apply_restriction", actionCalls.get(1).getName());
-        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(0).getParams());
-        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(1).getParams());
-    }
-
-    @Test
-    public void actionCalls_should_store_multiple_equal_actions_with_different_values_separately() {
-        String workflow = """
-            workflow 'test'
-                ruleset 'dummy'
-                    'rule_a' user_id = 15 return block with apply_restriction({'test': 'me'}) AND apply_restriction({'test': 'not_me'})
-                default allow
-            end
-        """;
-        Map<String, Object> request = Map.of("user_id", 15);
-        WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
-
-        List<Action> actionCalls = result.getActionCalls();
-        Assertions.assertEquals(2, actionCalls.size());
-
-        // Verify both actions have the same name but different parameters
-        Assertions.assertEquals("apply_restriction", actionCalls.get(0).getName());
-        Assertions.assertEquals("apply_restriction", actionCalls.get(1).getName());
-        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(0).getParams());
-        Assertions.assertEquals(Map.of("test", "not_me"), actionCalls.get(1).getParams());
-    }
-
 }

--- a/rules-interpreter/src/test/java/ActionCallsTest.java
+++ b/rules-interpreter/src/test/java/ActionCallsTest.java
@@ -1,10 +1,96 @@
 import io.github.iamrenny.ruleflow.vo.WorkflowResult;
+import io.github.iamrenny.ruleflow.vo.Action;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.List;
 
 class ActionCallsTest {
+
+    @Test
+    public void actionCalls_should_store_multiple_actions_with_same_name_separately() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'rule_a' user_id = 15 return block with apply_restriction({'test': 'me'}) AND apply_restriction({'responsible': 'homer'})                                                                           
+                default allow
+            end
+        """;
+        Map<String, Object> request = Map.of("user_id", 15);
+        WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
+        
+        List<Action> actionCalls = result.getActionCalls();
+        Assertions.assertEquals(2, actionCalls.size());
+        
+        // Verify both actions have the same name but different parameters
+        Assertions.assertEquals("apply_restriction", actionCalls.get(0).getName());
+        Assertions.assertEquals("apply_restriction", actionCalls.get(1).getName());
+        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(0).getParams());
+        Assertions.assertEquals(Map.of("responsible", "homer"), actionCalls.get(1).getParams());
+    }
+
+    @Test
+    public void actionCalls_should_work_with_different_action_names() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'rule_a' user_id = 15 return block with action('manual_review', {'test': 'me'}) and action('logout_user', {'reason': 'suspicious'})                                                                 
+                default allow
+            end
+        """;
+        Map<String, Object> request = Map.of("user_id", 15);
+        WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
+        
+        List<Action> actionCalls = result.getActionCalls();
+        Assertions.assertEquals(2, actionCalls.size());
+        Assertions.assertEquals("manual_review", actionCalls.get(0).getName());
+        Assertions.assertEquals("logout_user", actionCalls.get(1).getName());
+    }
+
+    @Test
+    public void actionCalls_should_store_multiple_equal_actions_separately() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'rule_a' user_id = 15 return block with apply_restriction({'test': 'me'}) AND apply_restriction({'test': 'me'})                                                                                     
+                default allow
+            end
+        """;
+        Map<String, Object> request = Map.of("user_id", 15);
+        WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
+
+        List<Action> actionCalls = result.getActionCalls();
+        Assertions.assertEquals(2, actionCalls.size());
+
+        // Verify both actions have the same name but different parameters
+        Assertions.assertEquals("apply_restriction", actionCalls.get(0).getName());
+        Assertions.assertEquals("apply_restriction", actionCalls.get(1).getName());
+        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(0).getParams());
+        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(1).getParams());
+    }
+
+    @Test
+    public void actionCalls_should_store_multiple_equal_actions_with_different_values_separately() {
+        String workflow = """
+            workflow 'test'
+                ruleset 'dummy'
+                    'rule_a' user_id = 15 return block with apply_restriction({'test': 'me'}) AND apply_restriction({'test': 'not_me'})                                                                                 
+                default allow
+            end
+        """;
+        Map<String, Object> request = Map.of("user_id", 15);
+        WorkflowResult result = new io.github.iamrenny.ruleflow.Workflow(workflow).evaluate(request);
+
+        List<Action> actionCalls = result.getActionCalls();
+        Assertions.assertEquals(2, actionCalls.size());
+
+        // Verify both actions have the same name but different parameters
+        Assertions.assertEquals("apply_restriction", actionCalls.get(0).getName());
+        Assertions.assertEquals("apply_restriction", actionCalls.get(1).getName());
+        Assertions.assertEquals(Map.of("test", "me"), actionCalls.get(0).getParams());
+        Assertions.assertEquals(Map.of("test", "not_me"), actionCalls.get(1).getParams());
+    }
 
     @Test
     public void given_multimatch_workflow_with_three_matching_rules_must_have_correct_actioncalls() {


### PR DESCRIPTION
# Fix: Add missing actionCalls methods to MatchedRuleListItem class

## 🐛 Problem
The `MatchedRuleListItem` class was missing essential methods for handling `actionCalls`, causing issues in multi-match workflows where `actionCalls` were not being properly mapped in the `matchedRules` list.

## 🔧 Solution
Added missing methods to `MatchedRuleListItem` class to ensure consistency with the main `WorkflowResult` class:

### Added Methods:
- `getActionCalls()` - Getter for actionCalls list
- `setActionCalls(List<Action> actionCalls)` - Setter with bidirectional conversion
- `setActionCalls(List<Action> actionCalls, boolean updateActionsWithParams)` - Conditional update
- `setActionsWithParams(Map<String, Map<String, String>> actionsWithParams)` - Updates all fields

### Key Features:
- ✅ Bidirectional conversion between `actionCalls` ↔ `actionsWithParams` ↔ `actions`
- ✅ Proper null handling
- ✅ Consistent behavior with main `WorkflowResult` class
- ✅ Maintains backward compatibility
- ✅ Clean implementation without deprecated methods

## 🧪 Testing
- ✅ Added new comprehensive test for multi-match scenarios
- ✅ Verified multi-match workflow with 3 matching rules
- ✅ All existing tests continue to pass
- ✅ No regressions introduced

**New Test Verifies:**
- Main result contains only first matched rule's actionCalls
- Each MatchedRuleListItem has its own complete actionCalls data
- Proper actionCalls mapping in multi-match scenarios

## 🎯 Impact
- ✅ Fixes actionCalls not being mapped in matchedRules
- ✅ Ensures consistent behavior across single-match and multi-match workflows
- ✅ Improves data integrity in WorkflowResult objects
- ✅ No breaking changes to existing API
- ✅ Clean, modern implementation without deprecated methods

## 📁 Files Changed
- `src/main/java/io/github/iamrenny/ruleflow/vo/WorkflowResult.java` - Added missing methods to MatchedRuleListItem
- `src/test/java/ActionCallsTest.java` - added new multi-match test
- `pom.xml` - Version bump from 0.9.1 to 0.9.2
- `rules-interpreter/pom.xml` - Version bump from 0.9.1 to 0.9.2  
- `rules-cli/pom.xml` - Version bump from 0.9.1 to 0.9.2

## ✅ Verification
- All tests pass 
- No linter errors
- Proper test organization with dedicated ActionCallsTest class
- Maintains existing functionality while fixing the reported issue
- Clean implementation following modern best practices